### PR TITLE
Add CredType Configuration to Enable srun Command 

### DIFF
--- a/slurm.conf
+++ b/slurm.conf
@@ -9,6 +9,7 @@ ControlAddr=slurmctld
 SlurmUser=root
 SlurmdUser=root
 AuthType=auth/none
+CredType=cred/none
 StateSaveLocation=/var/lib/slurmd
 SlurmdSpoolDir=/var/spool/slurmd
 SwitchType=switch/none


### PR DESCRIPTION
I noticed that srun was trying to authenticate users via munge, which we do not have installed. So I remove it by including a new configuration key.

Now, if you start the container, you should be able to execute jobs via `srun`. 